### PR TITLE
fix WebRTC multiplayer to work without hosting

### DIFF
--- a/src/api/webrtc.js
+++ b/src/api/webrtc.js
@@ -11,8 +11,8 @@ import { buffer_reader, read_packet, write_packet, client_packet, server_packet,
   }
 }*/
 
-const PeerID = name => `diabloweb_${name}`;
-const Options = {host: 'diablo.rivsoft.net', port: 443, secure: true};
+const PeerID = name => `diabloweb_dDv62yHQrZJP28tBEHL_${name}`;
+const Options = {port: 443, secure: true};
 const MAX_PLRS = 4;
 
 class webrtc_server {


### PR DESCRIPTION
Use the default https://peerjs.com/ server for the WebRTC connection.
I've also added a random string to the connection id to make it unlikely that someone accidentally is using the same id...