### PR TITLE
fix sound not playing in Safari

### DIFF
--- a/src/api/sound.js
+++ b/src/api/sound.js
@@ -25,6 +25,7 @@ export default function init_sound() {
   let context = null;
   try {
     context = new AudioContext();
+    context.resume();
   } catch (e) {
   }
   const sounds = new Map();


### PR DESCRIPTION
Safari requires context.resume() to start playing sound